### PR TITLE
Feat/api documentation

### DIFF
--- a/README-APIs.md
+++ b/README-APIs.md
@@ -1,1 +1,79 @@
-// TODO Document APIs (with tools like Swagger, ideally automated)
+# API Documentation with springdoc-openapi
+
+This document outlines the implementation of our automated API documentation, explains its underlying mechanics, and records key decisions regarding technical debt for future improvements.
+
+---
+
+## Overview
+
+To provide a clear, interactive, and always up-to-date reference for our API, we have integrated **`springdoc-openapi`**. This library automatically generates an **OpenAPI 3.0 specification** for our Spring Boot application and serves it through an interactive **Swagger UI**.
+
+This approach ensures that our documentation is never out of sync with our code, as it's generated directly from the source.
+
+---
+
+## How It Works
+
+The `springdoc-openapi` library works by hooking into the Spring application's startup process. Here's a step-by-step breakdown of what it does:
+
+1.  **Code Scanning:** At startup, the library scans the application's compiled code.
+2.  **Endpoint Discovery:** It looks for standard Spring web annotations (`@RestController`, `@RequestMapping`, `@GetMapping`, `@PostMapping`, etc.) to identify all available API endpoints, their paths, and their HTTP methods.
+3.  **Schema Generation:** It inspects the method signatures of your controller functions to determine the structure of requests and responses.
+    * It uses annotations like `@PathVariable` and `@RequestParam` for parameters.
+    * Crucially, for a `@RequestBody`, it analyzes the **data class (DTO)** specified in the method signature (e.g., `fun login(@RequestBody request: TokenRequest)`) to build the request body schema.
+4.  **Annotation Processing:** It reads the OpenAPI annotations we've added (`@Operation`, `@Tag`, `@ApiResponse`, `@SecurityScheme`) to enrich the generated documentation with human-readable descriptions, examples, and security information.
+5.  **Serving the Documentation:** Finally, it exposes two key endpoints:
+    * `/v3/api-docs`: A raw JSON file containing the complete OpenAPI 3.0 specification.
+    * `/swagger-ui.html`: An interactive HTML page (Swagger UI) that consumes the JSON from `/v3/api-docs` and presents it in a user-friendly format.
+
+---
+
+## Implementation Steps
+
+The integration was completed in three main steps:
+
+1.  **Added Dependency:** The `org.springdoc:springdoc-openapi-starter-webmvc-ui` library was added to our `build.gradle.kts` file.
+
+2.  **Configured Application:** The main `Application.kt` file was annotated to provide global API metadata and define our security scheme for JWT authentication.
+    * `@OpenAPIDefinition`: Sets the title and version for the API.
+    * `@SecurityScheme`: Configures the "Authorize" button in Swagger UI to allow developers to use a JWT Bearer token for testing protected endpoints.
+
+3.  **Annotated Controllers:** All controller classes were enhanced with OpenAPI annotations to provide detailed descriptions for every endpoint, including summaries, potential responses, and parameter information.
+
+---
+
+## Accessing the Documentation
+
+With the application running, the documentation is available at the following URLs:
+
+-   **Interactive Swagger UI:** `http://localhost:8080/swagger-ui.html`
+-   **Raw OpenAPI Spec (JSON):** `http://localhost:8080/v3/api-docs`
+
+---
+
+## Known Issues & Technical Debt
+
+### Shared DTOs Leading to Inaccurate Schemas
+
+During implementation, we identified an issue where the generated documentation for some endpoints is not perfectly accurate. This is a deliberate technical debt trade-off we have made to avoid immediate, large-scale refactoring.
+
+-   **The Cause:** We are reusing the same Data Transfer Object (DTO) for multiple, distinct API operations. E.g., the `TokenRequest` DTO, which is used for both user registration and user login.
+
+-   **The Impact:** The `TokenRequest` DTO contains fields for `name`, `email`, `password`, `role`, and `slackUserId`. While all of these are relevant for registration, a login operation only requires `email` and `password`. Because the `/auth/login` endpoint uses the `TokenRequest` DTO, the API documentation incorrectly suggests that all fields are part of the login request.
+
+-   **Decision:** We have accepted this documentation inaccuracy for now, with a plan to address it in the future.
+
+---
+
+## Future Work
+
+### Refactor DTOs for Specificity
+
+To resolve the technical debt and improve our API design, we will refactor all our DTOs to be specific to their use case.
+
+**Exemplary Action Plan for `TokenRequest` DTO:**
+1.  **Create Specific DTOs:** Create new data classes like `LoginRequest` (with only `email`, `password`) and `RegisterRequest` (with `name`, `email`, `password`, `slackUserId`).
+2.  **Update Controllers:** Update the method signatures in the `AuthController` to use these new, specific DTOs.
+3.  **Update Services:** Adjust the `AuthService` layer to accept the new DTOs.
+
+This refactoring will not only fix the documentation but also lead to a more robust and self-documenting API.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.10")
 }
 
 kotlin {

--- a/src/main/kotlin/ecommerce/Application.kt
+++ b/src/main/kotlin/ecommerce/Application.kt
@@ -1,10 +1,28 @@
 package ecommerce
 
 import ecommerce.config.StripeProperties
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.security.SecurityScheme
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
+@OpenAPIDefinition(
+    info =
+        Info(
+            title = "Spaeti SnackEnd API",
+            version = "v0.1",
+            description = "API documentation for the Spaeti SnackEnd e-commerce application.",
+        ),
+)
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    bearerFormat = "JWT",
+    scheme = "bearer"
+)
 @EnableConfigurationProperties(StripeProperties::class)
 @SpringBootApplication
 class Application

--- a/src/main/kotlin/ecommerce/Application.kt
+++ b/src/main/kotlin/ecommerce/Application.kt
@@ -21,7 +21,7 @@ import org.springframework.boot.runApplication
     name = "bearerAuth",
     type = SecuritySchemeType.HTTP,
     bearerFormat = "JWT",
-    scheme = "bearer"
+    scheme = "bearer",
 )
 @EnableConfigurationProperties(StripeProperties::class)
 @SpringBootApplication

--- a/src/main/kotlin/ecommerce/controller/AdminController.kt
+++ b/src/main/kotlin/ecommerce/controller/AdminController.kt
@@ -3,6 +3,9 @@ package ecommerce.controller
 import ecommerce.dto.MemberResponse
 import ecommerce.dto.TopProductStatResponse
 import ecommerce.service.CartService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -13,14 +16,29 @@ import org.springframework.web.bind.annotation.RestController
 class AdminController(
     private val cartService: CartService,
 ) {
+    @Operation(summary = "Get top 5 products added to carts in last 30 days")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Successfully retrieved top products"),
+            ApiResponse(responseCode = "401", description = "Unauthorized"),
+            ApiResponse(responseCode = "403", description = "Forbidden (user is not an admin)")
+        ]
+    )
     @GetMapping("/top-products")
     fun findTop5ProductsInLast30Days(): ResponseEntity<List<TopProductStatResponse>> {
         val topProducts = cartService.findTop5ProductsInLast30Days()
         return ResponseEntity.ok(topProducts)
     }
 
-    @GetMapping("/cart-activity")
-    fun findMembersWithCartActivityInLast7Days(): ResponseEntity<List<MemberResponse>> {
+    @Operation(summary = "Get users with cart activity in last 7 days")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Successfully retrieved active members"),
+            ApiResponse(responseCode = "401", description = "Unauthorized"),
+            ApiResponse(responseCode = "403", description = "Forbidden (user is not an admin)")
+        ]
+    )
+    @GetMapping("/cart-activity")    fun findMembersWithCartActivityInLast7Days(): ResponseEntity<List<MemberResponse>> {
         val activeMembers = cartService.findMembersWithCartActivityInLast7Days()
         return ResponseEntity.ok(activeMembers)
     }

--- a/src/main/kotlin/ecommerce/controller/AdminController.kt
+++ b/src/main/kotlin/ecommerce/controller/AdminController.kt
@@ -21,8 +21,8 @@ class AdminController(
         value = [
             ApiResponse(responseCode = "200", description = "Successfully retrieved top products"),
             ApiResponse(responseCode = "401", description = "Unauthorized"),
-            ApiResponse(responseCode = "403", description = "Forbidden (user is not an admin)")
-        ]
+            ApiResponse(responseCode = "403", description = "Forbidden (user is not an admin)"),
+        ],
     )
     @GetMapping("/top-products")
     fun findTop5ProductsInLast30Days(): ResponseEntity<List<TopProductStatResponse>> {
@@ -35,10 +35,11 @@ class AdminController(
         value = [
             ApiResponse(responseCode = "200", description = "Successfully retrieved active members"),
             ApiResponse(responseCode = "401", description = "Unauthorized"),
-            ApiResponse(responseCode = "403", description = "Forbidden (user is not an admin)")
-        ]
+            ApiResponse(responseCode = "403", description = "Forbidden (user is not an admin)"),
+        ],
     )
-    @GetMapping("/cart-activity")    fun findMembersWithCartActivityInLast7Days(): ResponseEntity<List<MemberResponse>> {
+    @GetMapping("/cart-activity")
+    fun findMembersWithCartActivityInLast7Days(): ResponseEntity<List<MemberResponse>> {
         val activeMembers = cartService.findMembersWithCartActivityInLast7Days()
         return ResponseEntity.ok(activeMembers)
     }

--- a/src/main/kotlin/ecommerce/controller/AuthController.kt
+++ b/src/main/kotlin/ecommerce/controller/AuthController.kt
@@ -4,6 +4,11 @@ import ecommerce.dto.MemberResponse
 import ecommerce.dto.TokenRequest
 import ecommerce.dto.TokenResponse
 import ecommerce.service.AuthService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -12,11 +17,19 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Authentication", description = "APIs for user registration and login")
 @RestController
 @RequestMapping("/auth")
 class AuthController(
     private val authService: AuthService,
 ) {
+    @Operation(summary = "Register a new user", description = "Creates a new user account and returns a JWT.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "User registered successfully"),
+            ApiResponse(responseCode = "400", description = "Validation error, e.g., email already exists")
+        ]
+    )
     @PostMapping("/register")
     fun register(
         @RequestBody request: TokenRequest,
@@ -25,6 +38,13 @@ class AuthController(
         return ResponseEntity.ok(tokenResponse)
     }
 
+    @Operation(summary = "Log in a user", description = "Authenticates a user and returns a new JWT.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Login successful"),
+            ApiResponse(responseCode = "401", description = "Invalid email or password")
+        ]
+    )
     @PostMapping("/login")
     fun login(
         @RequestBody request: TokenRequest,
@@ -33,6 +53,14 @@ class AuthController(
         return ResponseEntity.ok(tokenResponse)
     }
 
+    @Operation(summary = "Get current user's info", description = "Retrieves the logged-in user's details using their JWT.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "User details found"),
+            ApiResponse(responseCode = "401", description = "Invalid or expired token")
+        ]
+    )
     @GetMapping("/find-member")
     fun findMember(
         @RequestHeader("Authorization") authHeader: String,

--- a/src/main/kotlin/ecommerce/controller/AuthController.kt
+++ b/src/main/kotlin/ecommerce/controller/AuthController.kt
@@ -27,8 +27,8 @@ class AuthController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "User registered successfully"),
-            ApiResponse(responseCode = "400", description = "Validation error, e.g., email already exists")
-        ]
+            ApiResponse(responseCode = "400", description = "Validation error, e.g., email already exists"),
+        ],
     )
     @PostMapping("/register")
     fun register(
@@ -42,8 +42,8 @@ class AuthController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "Login successful"),
-            ApiResponse(responseCode = "401", description = "Invalid email or password")
-        ]
+            ApiResponse(responseCode = "401", description = "Invalid email or password"),
+        ],
     )
     @PostMapping("/login")
     fun login(
@@ -58,8 +58,8 @@ class AuthController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "User details found"),
-            ApiResponse(responseCode = "401", description = "Invalid or expired token")
-        ]
+            ApiResponse(responseCode = "401", description = "Invalid or expired token"),
+        ],
     )
     @GetMapping("/find-member")
     fun findMember(

--- a/src/main/kotlin/ecommerce/controller/CartController.kt
+++ b/src/main/kotlin/ecommerce/controller/CartController.kt
@@ -7,6 +7,10 @@ import ecommerce.dto.MemberResponse
 import ecommerce.entity.Cart
 import ecommerce.entity.CartItem
 import ecommerce.service.CartService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
@@ -22,11 +26,18 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
+@Tag(name = "Cart", description = "APIs for managing the user shopping cart")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/api/protected/cart")
 class CartController(
     private val cartService: CartService,
 ) {
+    @Operation(
+        summary = "Add an item to the cart",
+        description = "Adds a product option to the current user's cart. If the item already exists, its quantity is increased."
+    )
+    @ApiResponse(responseCode = "201", description = "Item added successfully")
     @PostMapping("/created")
     fun addToCart(
         @RequestBody request: CartRequest,
@@ -38,6 +49,8 @@ class CartController(
         ).build()
     }
 
+    @Operation(summary = "Remove an item from the cart")
+    @ApiResponse(responseCode = "204", description = "Item removed successfully")
     @DeleteMapping("/{cartItemId}")
     fun removeFromCart(
         @PathVariable cartItemId: Long,
@@ -46,6 +59,7 @@ class CartController(
         return ResponseEntity.noContent().build()
     }
 
+    @Operation(summary = "Get the current user's cart")
     @GetMapping
     fun getCart(
         @LoginMember member: LoggedInMember,
@@ -53,6 +67,7 @@ class CartController(
         return cartService.getCart(member.id)
     }
 
+    @Operation(summary = "Get items in the cart (paginated)", hidden = true)
     @GetMapping("/paged")
     fun getCartItems(
         @PageableDefault(size = 10, sort = ["created_at"]) pageable: Pageable,
@@ -67,6 +82,7 @@ class CartController(
         )
     }
 
+    @Operation(summary = "Find cart items by quantity (paginated)", hidden = true)
     @GetMapping("/quantity")
     fun getByQuantity(
         @RequestParam quantity: Long,

--- a/src/main/kotlin/ecommerce/controller/CartController.kt
+++ b/src/main/kotlin/ecommerce/controller/CartController.kt
@@ -35,7 +35,7 @@ class CartController(
 ) {
     @Operation(
         summary = "Add an item to the cart",
-        description = "Adds a product option to the current user's cart. If the item already exists, its quantity is increased."
+        description = "Adds a product option to the current user's cart. If the item already exists, its quantity is increased.",
     )
     @ApiResponse(responseCode = "201", description = "Item added successfully")
     @PostMapping("/created")

--- a/src/main/kotlin/ecommerce/controller/OrderController.kt
+++ b/src/main/kotlin/ecommerce/controller/OrderController.kt
@@ -9,6 +9,9 @@ import ecommerce.dto.PlaceOrderResponse
 import ecommerce.repository.MemberRepositoryJpa
 import ecommerce.service.MemberService
 import ecommerce.service.OrderService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -24,8 +27,15 @@ class OrderController(
     private val memberService: MemberService,
     private val memberRepository: MemberRepositoryJpa,
 ) {
-    @PostMapping
-    fun placeOrder(
+    @Operation(summary = "Place an order for a single item")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "Order placed successfully"),
+            ApiResponse(responseCode = "400", description = "Invalid input or insufficient stock"),
+            ApiResponse(responseCode = "500", description = "Payment processing failed")
+        ]
+    )
+    @PostMapping    fun placeOrder(
         @LoginMember principal: LoggedInMember,
         @Valid @RequestBody req: PlaceOrderRequest,
     ): ResponseEntity<PlaceOrderResponse> {
@@ -34,6 +44,14 @@ class OrderController(
         return ResponseEntity.created(URI.create("/orders/${res.orderId}")).body(res)
     }
 
+    @Operation(summary = "Create an order from all items in the cart")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "Checkout successful"),
+            ApiResponse(responseCode = "400", description = "Invalid input or empty cart"),
+            ApiResponse(responseCode = "500", description = "Payment processing failed")
+        ]
+    )
     @PostMapping("/checkout")
     fun checkoutCart(
         @LoginMember member: LoggedInMember,
@@ -49,6 +67,14 @@ class OrderController(
             .body(res)
     }
 
+    @Operation(summary = "Create a gift order from all items in the cart")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "Gift order placed successfully"),
+            ApiResponse(responseCode = "400", description = "Invalid input or empty cart"),
+            ApiResponse(responseCode = "500", description = "Payment processing failed")
+        ]
+    )
     @PostMapping("/gift")
     fun placeGiftOrder(
         @LoginMember member: LoggedInMember,

--- a/src/main/kotlin/ecommerce/controller/OrderController.kt
+++ b/src/main/kotlin/ecommerce/controller/OrderController.kt
@@ -32,10 +32,11 @@ class OrderController(
         value = [
             ApiResponse(responseCode = "201", description = "Order placed successfully"),
             ApiResponse(responseCode = "400", description = "Invalid input or insufficient stock"),
-            ApiResponse(responseCode = "500", description = "Payment processing failed")
-        ]
+            ApiResponse(responseCode = "500", description = "Payment processing failed"),
+        ],
     )
-    @PostMapping    fun placeOrder(
+    @PostMapping
+    fun placeOrder(
         @LoginMember principal: LoggedInMember,
         @Valid @RequestBody req: PlaceOrderRequest,
     ): ResponseEntity<PlaceOrderResponse> {
@@ -49,8 +50,8 @@ class OrderController(
         value = [
             ApiResponse(responseCode = "201", description = "Checkout successful"),
             ApiResponse(responseCode = "400", description = "Invalid input or empty cart"),
-            ApiResponse(responseCode = "500", description = "Payment processing failed")
-        ]
+            ApiResponse(responseCode = "500", description = "Payment processing failed"),
+        ],
     )
     @PostMapping("/checkout")
     fun checkoutCart(
@@ -72,8 +73,8 @@ class OrderController(
         value = [
             ApiResponse(responseCode = "201", description = "Gift order placed successfully"),
             ApiResponse(responseCode = "400", description = "Invalid input or empty cart"),
-            ApiResponse(responseCode = "500", description = "Payment processing failed")
-        ]
+            ApiResponse(responseCode = "500", description = "Payment processing failed"),
+        ],
     )
     @PostMapping("/gift")
     fun placeGiftOrder(

--- a/src/main/kotlin/ecommerce/controller/ProductController.kt
+++ b/src/main/kotlin/ecommerce/controller/ProductController.kt
@@ -3,6 +3,10 @@ package ecommerce.controller
 import ecommerce.dto.ProductRequest
 import ecommerce.entity.Product
 import ecommerce.service.ProductService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -22,12 +26,21 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
+@Tag(name = "Products", description = "APIs for product management")
 @Validated
 @RestController
 @RequestMapping("/products")
 class ProductController(
     private val productService: ProductService,
 ) {
+    @Operation(
+        summary = "Create a new product",
+        description = "Creates a new product with one or more options. Product name must be unique.",
+        responses = [
+            ApiResponse(responseCode = "201", description = "Product created successfully"),
+            ApiResponse(responseCode = "400", description = "Invalid input, such as a validation error or duplicate name"),
+        ],
+    )
     @PostMapping
     @ResponseBody
     fun create(
@@ -38,12 +51,21 @@ class ProductController(
         return ResponseEntity.created(URI.create("/products/${product.id}")).build()
     }
 
+    @Operation(summary = "Get all products (unpaged)")
     @GetMapping
     @ResponseBody
     fun readAll(): List<Product> {
         return productService.getAllProductsUnpaged()
     }
 
+    @Operation(summary = "Update an existing product")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Product updated successfully"),
+            ApiResponse(responseCode = "400", description = "Invalid input data"),
+            ApiResponse(responseCode = "404", description = "Product not found")
+        ]
+    )
     @PutMapping("/{id}")
     @ResponseBody
     fun update(
@@ -54,6 +76,13 @@ class ProductController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "Delete a product")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "Product deleted successfully"),
+            ApiResponse(responseCode = "404", description = "Product not found")
+        ]
+    )
     @DeleteMapping("/{id}")
     @ResponseBody
     fun delete(
@@ -63,6 +92,10 @@ class ProductController(
         return ResponseEntity.noContent().build()
     }
 
+    @Operation(
+        summary = "Get all products (paginated)",
+        description = "Provides a paginated list of products. Supports sorting by fields like 'name' and 'price'."
+    )
     @GetMapping("/paged")
     fun getAllProducts(
         @PageableDefault(size = 10, sort = ["name"]) pageable: Pageable,
@@ -75,6 +108,7 @@ class ProductController(
         )
     }
 
+    @Operation(summary = "Get products by price (paginated)")
     @GetMapping("/price")
     fun getByPrice(
         @RequestParam price: Double,

--- a/src/main/kotlin/ecommerce/controller/ProductController.kt
+++ b/src/main/kotlin/ecommerce/controller/ProductController.kt
@@ -63,8 +63,8 @@ class ProductController(
         value = [
             ApiResponse(responseCode = "200", description = "Product updated successfully"),
             ApiResponse(responseCode = "400", description = "Invalid input data"),
-            ApiResponse(responseCode = "404", description = "Product not found")
-        ]
+            ApiResponse(responseCode = "404", description = "Product not found"),
+        ],
     )
     @PutMapping("/{id}")
     @ResponseBody
@@ -80,8 +80,8 @@ class ProductController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "204", description = "Product deleted successfully"),
-            ApiResponse(responseCode = "404", description = "Product not found")
-        ]
+            ApiResponse(responseCode = "404", description = "Product not found"),
+        ],
     )
     @DeleteMapping("/{id}")
     @ResponseBody
@@ -94,7 +94,7 @@ class ProductController(
 
     @Operation(
         summary = "Get all products (paginated)",
-        description = "Provides a paginated list of products. Supports sorting by fields like 'name' and 'price'."
+        description = "Provides a paginated list of products. Supports sorting by fields like 'name' and 'price'.",
     )
     @GetMapping("/paged")
     fun getAllProducts(


### PR DESCRIPTION
# Description

This PR introduces comprehensive, automated API documentation by integrating springdoc-openapi. It generates an OpenAPI 3 specification from our controllers and serves it via an interactive Swagger UI.

This provides a single source of truth for our API, allowing developers to easily explore and test endpoints directly from their browser.

Fixes https://github.com/users/deniz-oezdemir/projects/2/views/1?pane=issue&itemId=124165375&issue=deniz-oezdemir%7CSpaeti-SnackEnd%7C6

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

The changes were tested manually by running the application and verifying the following:

- [x] The Swagger UI loads correctly at http://localhost:8080/swagger-ui.html.
- [x] All controllers and their respective endpoints are present.
- [x] The raw API specification is available at /v3/api-docs.

# Checklist

Please go through each item and mark [x] when complete.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added comments to my code, especially in hard-to-understand areas
- [x] I have updated the documentation as needed
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

# Technical Debt Note

During implementation, we identified an issue where the generated documentation for some endpoints is not perfectly accurate. This is a deliberate technical debt trade-off we have made to avoid immediate, large-scale refactoring.

-   **The Cause:** We are reusing the same Data Transfer Object (DTO) for multiple, distinct API operations. E.g., the `TokenRequest` DTO, which is used for both user registration and user login.

-   **The Impact:** The `TokenRequest` DTO contains fields for `name`, `email`, `password`, `role`, and `slackUserId`. While all of these are relevant for registration, a login operation only requires `email` and `password`. Because the `/auth/login` endpoint uses the `TokenRequest` DTO, the API documentation incorrectly suggests that all fields are part of the login request.

-   **Decision:** We have accepted this documentation inaccuracy for now, with a plan to address it in the future.

# Reference

[springdoc-openapi Project](https://springdoc.org/)
