### PR TITLE
Fix/properties jwt expiry limits

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -25,7 +25,7 @@ spring.sql.init.mode=never
 
 # JWT / Security
 security.jwt.token.secret-key=
-security.jwt.token.expire-time-millis=${TOKEN_EXPIRE_LENGTH:3600000}
+security.jwt.token.expire-time-millis=3600000
 
 # Stripe
 stripe.secret=


### PR DESCRIPTION
This pull request makes a small configuration change to the `src/main/resources/application-prod.properties` file. The change sets the JWT token expiration time to a fixed value rather than using an environment variable.