### PR TITLE
refactor(properties): fix: Exclude H2 database from production build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation("com.slack.api:slack-api-client:1.36.1")
     implementation("org.liquibase:liquibase-core")
-    runtimeOnly("com.h2database:h2")
+    testRuntimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -51,6 +51,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.10")
+
 }
 
 kotlin {

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -25,7 +25,7 @@ spring.sql.init.mode=never
 
 # JWT / Security
 security.jwt.token.secret-key=
-security.jwt.token.expire-time-millis=${TOKEN_EXPIRE_LENGTH:3600000}
+security.jwt.token.expire-time-millis=3600000
 
 # Stripe
 stripe.secret=


### PR DESCRIPTION
I changed the builde.gradle.kt file to runtestOnly for H2 Data Base 