### PR TITLE
add placeholder variables back to properties

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -7,9 +7,9 @@ server.error.whitelabel.enabled=false
 spring.config.import=optional:file:/home/ubuntu/secrets/application-secrets.properties
 
 # RDS PostgreSQL (app_user)
-spring.datasource.url=
-spring.datasource.username=
-spring.datasource.password=
+spring.datasource.url=${DB_APP_URL}
+spring.datasource.username=${DB_APP_USER}
+spring.datasource.password=${DB_APP_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 


### PR DESCRIPTION
This pull request updates the production database configuration to use environment variables for improved security and flexibility.

Configuration changes:

* Updated `spring.datasource.url`, `spring.datasource.username`, and `spring.datasource.password` in `application-prod.properties` to reference environment variables (`DB_APP_URL`, `DB_APP_USER`, `DB_APP_PASSWORD`) instead of hardcoded values.