### PR TITLE
Fix/prod deployment

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,4 +21,5 @@ artifacts:
     - build/libs/*.jar
     - appspec.yml
     - scripts/**/*
+    - src/main/resources/**/*
   discard-paths: no

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+echo ">>> [BeforeInstall] Creating log directory..."
+mkdir -p /home/ubuntu/logs
+
 echo ">>> [BeforeInstall] Stopping current application if running..."
 pkill -f 'java -jar' || true
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+exit 1
 JAR_FILE=$(ls /home/ubuntu/app/build/libs/*.jar | head -n 1)
 
 if [ -z "$JAR_FILE" ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -8,4 +8,4 @@ fi
 
 echo ">>> ####### Test #######"
 echo ">>> [ApplicationStart] Starting application: $JAR_FILE"
-nohup sudo -E java -jar -Dspring.profiles.active=prod $JAR_FILE > /home/ubuntu/app/app.log 2>&1 &
+nohup sudo -E java -jar -Dspring.profiles.active=prod -Dspring.jpa.defer-datasource-initialization=true $JAR_FILE > /home/ubuntu/app/app.log 2>&1 &

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-exit 1
 JAR_FILE=$(ls /home/ubuntu/app/build/libs/*.jar | head -n 1)
 
 if [ -z "$JAR_FILE" ]; then
@@ -9,4 +8,4 @@ fi
 
 echo ">>> ####### Test #######"
 echo ">>> [ApplicationStart] Starting application: $JAR_FILE"
-nohup sudo -E java -jar -Dspring.profiles.active=prod -Dspring.jpa.defer-datasource-initialization=true $JAR_FILE > /home/ubuntu/app/app.log 2>&1 &
+nohup java -jar -Dspring.profiles.active=prod $JAR_FILE > /home/ubuntu/app/app.log 2>&1 &

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,31 +1,31 @@
-spring.config.activate.on-profile=dev
 spring.application.name=spring-ecommerce-dev
-server.port=8080
-server.error.whitelabel.enabled=false
 
-# Local Postgres
+# Local Postgres (adjust if needed)
 spring.datasource.url=jdbc:postgresql://localhost:5432/spaeti_dev
 spring.datasource.username=master_user
 spring.datasource.password=
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.database-platform=postgresql
 
-# JPA safety
+# JPA + Liquibase
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=false
-spring.jpa.defer-datasource-initialization=false
 spring.h2.console.enabled=false
 
-# IMPORTANT: do not auto-run schema/data in dev (we already created tables)
-spring.sql.init.mode=never
-
-# Observability
-management.health.mail.enabled=false
-# Enable liquibase for this profile
+# Liquibase
 spring.liquibase.enabled=true
-# Point to the correct Liquibase changelog file
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 
-logging.level.liquibase=DEBUG
+# Security/Stripe (dev-only dummies to avoid 500s)
+security.jwt.token.secret-key=dGV2LXNlY3JldC0zMmJ5dGVzLWJhc2U2NC0tLQ==
+security.jwt.token.expire-time-millis=3600000
+stripe.secret=sk_test_dummy
+
+# Mail placeholders (if unused)
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=
+spring.mail.password=
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -13,7 +13,7 @@ spring.datasource.password=${DB_APP_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA safety: only validate schema in prod
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
 spring.jpa.defer-datasource-initialization=true
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -11,33 +11,29 @@ spring.datasource.url=${DB_APP_URL}
 spring.datasource.username=${DB_APP_USER}
 spring.datasource.password=${DB_APP_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 # JPA safety: only validate schema in prod
 spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=false
-spring.jpa.defer-datasource-initialization=false
-spring.h2.console.enabled=false
+spring.jpa.show-sql=false
 
 # IMPORTANT: Do not auto-run schema/data in prod
 spring.sql.init.mode=never
 
+# Liquibase
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
+
 # JWT / Security
-security.jwt.token.secret-key=${JWT_SECRET:}
-security.jwt.token.expire-time-millis=${TOKEN_EXPIRE_LENGTH:3600000}
+security.jwt.token.secret-key=${JWT_SECRET}
+security.jwt.token.expire-time-millis=3600000
 
 # Stripe
-stripe.secret=${STRIPE_SECRET_KEY:}
-
-# Point to the correct Liquibase changelog file
-spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
+stripe.secret=${STRIPE_SECRET}
 
 # Mail
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=${SMTP_USER:}
-spring.mail.password=${SMTP_PASSWORD:}
+spring.mail.username=${SMTP_USER}
+spring.mail.password=${SMTP_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
@@ -46,4 +42,4 @@ management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
 
 # Slack
-slack.bot.token=${SLACK_BOT_TOKEN:}
+slack.bot.token=${SLACK_BOT_TOKEN}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,46 +1,33 @@
-spring.config.activate.on-profile=prod
 spring.application.name=spring-ecommerce
-server.port=8080
-server.error.whitelabel.enabled=false
 
-# Secrets file on EC2 (DB, JWT, Stripe, Mail, Slack, etc.)
+# Pull secrets from the EC2 file (already on your box)
 spring.config.import=optional:file:/home/ubuntu/secrets/application-secrets.properties
 
-# RDS PostgreSQL (app_user)
+# RDS datasource (values come from the secrets file)
 spring.datasource.url=${DB_APP_URL}
 spring.datasource.username=${DB_APP_USER}
 spring.datasource.password=${DB_APP_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# JPA safety: only validate schema in prod
+# JPA
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
-spring.jpa.defer-datasource-initialization=true
-
-# IMPORTANT: Do not auto-run schema/data in prod
-spring.sql.init.mode=never
 
 # Liquibase
+spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 
-# JWT / Security
+# Security (from secrets)
 security.jwt.token.secret-key=${JWT_SECRET}
 security.jwt.token.expire-time-millis=3600000
 
-# Stripe
+# Stripe (from secrets)
 stripe.secret=${STRIPE_SECRET}
 
-# Mail
+# Mail (from secrets)
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=${SMTP_USER}
 spring.mail.password=${SMTP_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
-
-# Observability
-management.endpoints.web.exposure.include=health,info
-management.endpoint.health.show-details=always
-
-# Slack
-slack.bot.token=${SLACK_BOT_TOKEN}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -15,6 +15,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 # JPA safety: only validate schema in prod
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
+spring.jpa.defer-datasource-initialization=true
 
 # IMPORTANT: Do not auto-run schema/data in prod
 spring.sql.init.mode=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,62 +1,19 @@
-# === Local development (default) ===
 spring.application.name=spring-ecommerce
 server.port=8080
-server.error.whitelabel.enabled=false
 
-# H2 in-memory DB for dev/tests
-#spring.h2.console.enabled=true
-spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL
-#spring.datasource.driver-class-name=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-
-# Do not auto-run schema/data locally (tests seed manually if needed)
-spring.jpa.defer-datasource-initialization=true
-spring.sql.init.mode=never
-
-# JWT / Security (placeholders for local only)
-security.jwt.token.secret-key=
-security.jwt.token.expire-time-millis=3600000
-
-# Stripe (placeholder for local only)
-stripe.secret=
-
-# Mail (placeholder for local only)
-spring.mail.host=smtp.gmail.com
-spring.mail.port=587
-spring.mail.username=
-spring.mail.password=
-spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.starttls.enable=true
-
-# Observability
+# Actuator
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
+management.health.mail.enabled=false
 
-# Slack
-slack.bot.token=
-
-# import local secrets file from ec2 instance
-spring.config.import=optional:file:/home/ubuntu/secrets/application-secrets.properties
-
-#logging strategy
-
-#shows INFO (and WARNS/ERROR) by default
+# Logging (safe defaults)
 logging.level.root=INFO
-logging.level.ecommerce=INFO
-logging.level.org.springframework.web=INFO
 logging.level.org.hibernate.SQL=WARN
-
-# add requestId (from MDC) to every console line
+logging.level.org.springframework.web=INFO
 logging.pattern.console=%d{ISO8601} %-5level [%X{requestId:-}] %logger{36} - %msg%n
 
-# aspect is off by default
-logging.tracing.service.enabled=false
+# Never let Spring?s SQL initializer run; Liquibase owns the schema
+spring.sql.init.mode=never
 
-# file paths used by logback-spring.xml
-APP_LOG_FILE=/home/ubuntu/logs/app.log
-ERROR_LOG_FILE=/home/ubuntu/logs/error.log
-
-spring.profiles.active=${ACTIVE_PROFILE}
-
+# If present on the box, load prod secrets
+spring.config.import=optional:file:/home/ubuntu/secrets/application-secrets.properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,10 +4,10 @@ server.port=8080
 server.error.whitelabel.enabled=false
 
 # H2 in-memory DB for dev/tests
-spring.h2.console.enabled=true
+#spring.h2.console.enabled=true
 spring.datasource.url=jdbc:h2:mem:test;MODE=PostgreSQL
-spring.datasource.driver-class-name=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=create
+#spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
@@ -57,3 +57,5 @@ logging.tracing.service.enabled=false
 # file paths used by logback-spring.xml
 APP_LOG_FILE=build/logs/app.log
 ERROR_LOG_FILE=build/logs/error.log
+
+spring.profiles.active=${ACTIVE_PROFILE}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,7 +55,8 @@ logging.pattern.console=%d{ISO8601} %-5level [%X{requestId:-}] %logger{36} - %ms
 logging.tracing.service.enabled=false
 
 # file paths used by logback-spring.xml
-APP_LOG_FILE=build/logs/app.log
-ERROR_LOG_FILE=build/logs/error.log
+APP_LOG_FILE=/home/ubuntu/logs/app.log
+ERROR_LOG_FILE=/home/ubuntu/logs/error.log
 
 spring.profiles.active=${ACTIVE_PROFILE}
+


### PR DESCRIPTION
# Description

This PR fixes the deployment issues encountered on the EC2 instance and finalizes the logging strategy for the Spaeti-SnackEnd application.

Deployment Fixes
	•	Secrets import: Ensured all application properties (application.properties, application-dev.properties, application-prod.properties) are correctly packaged and read by the application.
	•	Startup script: Removed sudo usage from scripts/start.sh to align with CodeDeploy best practices and prevent permission conflicts.
	•	Permissions: Added proper log directory creation (/home/ubuntu/logs) with ownership set to ubuntu, preventing Permission denied errors at startup.
	•	Secrets override: Updated application-secrets.properties on EC2 to set:
	
	
<img width="964" height="110" alt="Screenshot 2025-08-28 at 16 01 29" src="https://github.com/user-attachments/assets/59e2df91-62a9-42eb-8764-594e578f12df" />


Fixes #30 #80 

Logging Implementation
	•	Introduced Logback rolling file appenders alongside console logging.
	•	All logs now:
	•	Include request correlation IDs (MDC).
	•	Write to both console and files:
	•	/home/ubuntu/logs/app.log → all logs (rotated daily / 50MB max size).
	•	/home/ubuntu/logs/error.log → error-only logs (rotated daily / 20MB max size).
	•	Configurable per environment using placeholders (APP_LOG_FILE, ERROR_LOG_FILE) so local dev continues to log to build/logs/..., while prod logs are stored persistently under /home/ubuntu/logs/.


# Type of change

Please select the type of change by marking [x] in the relevant box.
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Manual testing

Manual testing (EC2)
-Verified application starts successfully on EC2.
-Confirmed /actuator/health returns UP.
-Verified logs are written to /home/ubuntu/logs/app.log and /home/ubuntu/logs/error.log.

Manual testing (Local)
-Verified logs continue to write to build/logs/app.log and build/logs/error.log when running via ./gradlew bootRun.

# Checklist

Please go through each item and mark [x] when complete.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added comments to my code, especially in hard-to-understand areas
- [x] I have updated the documentation as needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally with my changes

