### PR TITLE
fix(auth): fix token request for admin from user

### DIFF
--- a/src/main/kotlin/ecommerce/service/AuthService.kt
+++ b/src/main/kotlin/ecommerce/service/AuthService.kt
@@ -36,8 +36,6 @@ class AuthService(
             throw ValidationException("Email is already registered")
         }
 
-        val role = if (tokenRequest.email == "admin@example.com") "ADMIN" else "USER"
-
         val slackUserId = tokenRequest.slackUserId
 
         val member =
@@ -46,7 +44,7 @@ class AuthService(
                     name = tokenRequest.name,
                     email = tokenRequest.email,
                     password = tokenRequest.password,
-                    role = role,
+                    role = tokenRequest.role,
                     slackUserId = slackUserId,
                 ),
             )


### PR DESCRIPTION
This pull request updates the user registration logic in the `AuthService` class to allow the user's role to be specified directly in the registration request, instead of inferring it based on the email address.

User registration improvements:

* The role for a new member is now set directly from `tokenRequest.role` rather than conditionally assigning "ADMIN" for a specific email and "USER" otherwise.
* Removed the hardcoded logic that set the role to "ADMIN" only if the email was "admin@example.com".