### PR TITLE
fix(secret): remove jwt key

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -18,7 +18,7 @@ spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 
 # Security/Stripe (dev-only dummies to avoid 500s)
-security.jwt.token.secret-key=dGV2LXNlY3JldC0zMmJ5dGVzLWJhc2U2NC0tLQ==
+security.jwt.token.secret-key=
 security.jwt.token.expire-time-millis=3600000
 stripe.secret=sk_test_dummy
 


### PR DESCRIPTION
This pull request makes a minor configuration update to the development properties file. The change removes the value for the JWT token secret key, likely to prevent the use of a hardcoded secret in development.

- Removed the hardcoded value for `security.jwt.token.secret-key` in `application-dev.properties`, setting it to an empty string.